### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 packages = [{ include = "sitemap_parser", from = "." }]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 hishel = "*"
 httpx = { extras = ["http2"], version = "*" }
 lxml = "*"


### PR DESCRIPTION
Couldn't install package because of my local python version (3.11.6). Forked and ran tests with 3.11.6 and they ran through all green.

Cheers and happy holidays :)